### PR TITLE
Ability to run tox in lxc environments

### DIFF
--- a/lxc.py
+++ b/lxc.py
@@ -1,0 +1,51 @@
+import contextlib
+import os
+import subprocess
+import time
+
+
+class LxcContainer:
+    def __init__(self, environment, name):
+        self.name = name
+        image='ubuntu:{}'.format(environment)
+        subprocess.check_output(['lxc', 'launch', image, name]) 
+        self.wait_for_networking()
+
+    def wait_for_networking(self):
+        for _ in range(10):
+            if self.run_command('sh -c "curl -s --head http://archive.ubuntu.com > /dev/null"') == 0:
+                return  # We have networking, exit out
+            time.sleep(6)
+        raise Exception('Networking did not come up in 60 seconds')
+    
+    def setup_code_directory(self, tmp_directory):
+        subprocess.check_call(['lxc', 'file', 'push', '-rp', tmp_directory , 
+                               self.name + '/tmp'])
+        subprocess.check_call(['lxc', 'file', 'push', 
+                               os.environ['HOME'] + '/.ssh', '-rp',
+                               self.name + '/home/ubuntu/.ssh'])
+        subprocess.check_call(['lxc', 'file', 'push', '-rp',
+                               os.environ['HOME'] + '/.gitconfig',
+                               self.name + '/home/ubuntu/.gitconfig'])
+
+
+    def run_command(self, cmd):
+        lxc_command = 'lxc exec {} -- {}'.format(self.name, cmd)
+        print("Running {}".format(lxc_command))
+        process = subprocess.Popen(lxc_command,
+                        stdout=subprocess.PIPE,
+                        shell=True)
+        while process.poll() is None:
+            debug_message = process.stdout.readline().decode('utf-8').rstrip()
+            print(debug_message)
+        return process.returncode
+
+@contextlib.contextmanager
+def lxc_container(environment, cwd):
+    name = 'cpc-' + subprocess.check_output(['petname']).decode('utf-8').strip()
+    try:
+        instance = LxcContainer(environment, name)
+        instance.setup_code_directory(cwd)
+        yield instance
+    finally:
+        subprocess.check_call(['lxc', 'delete', '--force', name])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ simplejson
 click
 urwid
 GitPython
-launchpadlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ simplejson
 click
 urwid
 GitPython
+launchpadlib


### PR DESCRIPTION
This is useful for snaps that we are testing that are using a different
core than default (for example, using core18 or core20). Users can now
pass in --environment 18.04 to lpmptox to run the tests entirely in
lxc.

Contents of your .ssh directory and .gitconfig (both in the $HOME
directory) will be copied into the lxc container.