### PR TITLE
lpmptox: show hexsha and summary after checkout

### DIFF
--- a/lpmptox.py
+++ b/lpmptox.py
@@ -51,10 +51,17 @@ def runtox(source_repo, source_branch,
             source_repo,
             source_branch,
             local_repo))
-        git.Repo.clone_from(source_repo, local_repo,
-                            depth=1,
-                            single_branch=True,
-                            branch=source_branch)
+        repo = git.Repo.clone_from(
+            source_repo,
+            local_repo,
+            depth=1,
+            single_branch=True,
+            branch=source_branch
+        )
+        _write_debug(output_file, '{} {}'.format(
+            repo.head.object.hexsha,
+            repo.head.object.summary
+        )
 
         if environment is not None:
             _write_debug(output_file, 'Running `{}` in {} lxc environment ...'.format(tox_command, environment))
@@ -79,7 +86,7 @@ def _run_tox_locally(local_repo, tox_command, output_file):
     while process.poll() is None:
         _write_debug(output_file, process.stdout.readline().decode('utf-8').rstrip())
     return process.returncode
-        
+
 
 @click.command()
 @click.option('--mp-owner', help='LP username of the owner of the MP '


### PR DESCRIPTION
This will produce a message like the following after doing a clone:

5f3db12d001a068b4b640c5a1bf9f06c74d8380c snap: add additional python deps

This way I can confirm that a tox run actually had the latest commit.
