### PR TITLE
When using lshipit behind a firewall installing from pypi can fail. 

### DIFF
--- a/lpmptox.py
+++ b/lpmptox.py
@@ -73,8 +73,7 @@ def runtox(source_repo, source_branch,
 def _run_tox_in_lxc(environment, local_repo, tox_command, output_file):
     with lxc_container(environment, local_repo) as container:
         container.run_command('sudo apt update')
-        container.run_command('sudo apt install -y python3-pip')
-        container.run_command('sudo pip3 install tox')
+        container.run_command('sudo apt install -y python3-pip tox')
         # local_repo is same path in the container
         return container.run_command(tox_command + ' -c ' + local_repo)
 


### PR DESCRIPTION
Use archive version of tox instead

This is the case for our use case at Canonical CPC. If using lxc you can assume we have access to
cloud-images.ubuntu.com to download the image for the container and also that we have access to
the Ubuntu archive to provision the container.

This will often mean a downgrade in the tox version.