### PR TITLE
fix(git): search git root in parent directories

### DIFF
--- a/lpshipit.py
+++ b/lpshipit.py
@@ -154,7 +154,7 @@ def lpshipit(directory, source_branch, target_branch, mp_owner, debug):
         print("'%s' is not a directory" % directory)
         sys.exit(1)
 
-    repo = git.Repo(directory)
+    repo = git.Repo(directory, search_parent_directories=True)
 
     lp = _get_launchpad_client()
     lp_user = lp.me


### PR DESCRIPTION
Do not crash when running lpshipit from a sub-directory of the git repo. Before, the user would have raised a git.exc.InvalidGitRepositoryError if trying to run lpshipit from a subdir.